### PR TITLE
Updates: Neovim 0.8.3, config, lsp, neorg

### DIFF
--- a/lua/lsp_configs/lsp.lua
+++ b/lua/lsp_configs/lsp.lua
@@ -31,7 +31,7 @@ mason.setup({
 })
 
 mason_lspconfig.setup({
-    ensure_installed = { "clangd", "sumneko_lua" },
+    ensure_installed = { "clangd", "lua_ls" },
     automatic_installation = true,
 })
 
@@ -39,7 +39,7 @@ local diagnostics = require("lsp_configs.diagnostics")
 diagnostics.setup()
 
 require("lsp_configs.servers.clangd").setup()
-require("lsp_configs.servers.sumneko_lua").setup()
+require("lsp_configs.servers.lua_ls").setup()
 
 local setup_lsps = function()
     local lsp_handlers = require("lsp_configs.lsp_handlers")

--- a/lua/lsp_configs/lsp_handlers.lua
+++ b/lua/lsp_configs/lsp_handlers.lua
@@ -107,7 +107,7 @@ M.capabilities = nil
 local ok_cmp_nvim_lsp, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
 if ok_cmp_nvim_lsp then
     local capabilities = vim.lsp.protocol.make_client_capabilities()
-    M.capabilities = cmp_nvim_lsp.update_capabilities(capabilities)
+    M.capabilities = cmp_nvim_lsp.default_capabilities(capabilities)
 end
 
 return M

--- a/lua/lsp_configs/servers/lua_ls.lua
+++ b/lua/lsp_configs/servers/lua_ls.lua
@@ -11,7 +11,7 @@ table.insert(runtime_path, "lua/?.lua")
 table.insert(runtime_path, "lua/?/init.lua")
 
 -- https://github.com/folke/lua-dev.nvim
-local ok_lua_dev, lua_dev = pcall(require, "lua-dev")
+local ok_neodev, neodev = pcall(require, "neodev")
 
 local on_attach = function(client, bufnr)
     -- formatting is done by null-ls
@@ -39,17 +39,17 @@ local settings = {
 }
 
 M.setup = function()
-    if ok_lua_dev then
-        local luadev = lua_dev.setup({
+    if ok_neodev then
+        local luadev = neodev.setup({
             lspconfig = {
                 on_attach = on_attach,
                 capabilities = lsp_handlers.capabilities,
                 settings = settings,
             },
         })
-        lspconfig.sumneko_lua.setup(luadev)
+        lspconfig.lua_ls.setup(luadev)
     else
-        lspconfig.sumneko_lua.setup({
+        lspconfig.lua_ls.setup({
             on_attach = on_attach,
             capabilities = lsp_handlers.capabilities,
             settings = settings,

--- a/lua/plugin_configs/neorg.lua
+++ b/lua/plugin_configs/neorg.lua
@@ -7,22 +7,20 @@ end
 neorg.setup({
     load = {
         ["core.defaults"] = {},
+        ["core.norg.concealer"] = {},
         ["core.norg.dirman"] = {
             config = {
                 workspaces = {
                     home = "~/code/neorg/",
                 },
+                default_workspace = "home",
+                index = "index.norg",
             },
         },
         ["core.norg.journal"] = {
             config = {
                 workspace = "home",
                 journal_folder = "journal",
-            },
-        },
-        ["core.gtd.base"] = {
-            config = {
-                workspace = "home",
             },
         },
     },

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -102,7 +102,7 @@ return packer.startup(function(use)
     use("j-hui/fidget.nvim") -- LSP status endpoint handler
     use("weilbith/nvim-code-action-menu") -- Show code actions in a useful manner
     use("kosayoda/nvim-lightbulb") -- Show code actions in a useful manner
-    use("folke/lua-dev.nvim")
+    use("folke/neodev.nvim")
     use("ray-x/lsp_signature.nvim")
 
     -- Diagnostics
@@ -158,6 +158,7 @@ return packer.startup(function(use)
     -- Journal/Orgmode
     use({
         "nvim-neorg/neorg",
+        run = ":Neorg sync-parseres",
         requires = "nvim-lua/plenary.nvim",
     })
 


### PR DESCRIPTION
- Neovim 0.8.3
  - Updated to this version
  - Now installing to `/usr/bin/nvim` instead of just symlinking to `~/bin/`
- Configuration changes
  - Renamed `update_capabilities` to `default_capabilities` as suggested in the error messages
  - Renamed `lua-dev` to `neodev` and updated configuration code accordingly
- LSP
  - `sumneko_lua` was moved to `lua_ls`
  - Unsure, but I'm still getting a warning that I'm not using the right language server name when configuring stuff, although I do get lua lsp feedback like before.
- Neorg
  - Updated `packer` config to run `:Neorg sync-parsers` on plugin update
  - Removed `gtd` module as it was removed and will be re-written for the new `norg 1.0` syntax.
  - Added a `default_workspace` to always use the only one I have
  - Set the index file to `index.norg` to open it if I haven't created it yet (will only ever happen the first time I run Neovim on OS)
  - Added the `concealer` module

  See videos https://www.youtube.com/watch?v=NnmRVY22Lq8 and
  https://www.youtube.com/watch?v=Bi9JiW5nSig from the author on the
  basics of Neorg